### PR TITLE
fix: correct mods.toml configuration for Minecraft  1.20.1 compatibility

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,13 +14,13 @@ OMO
 [[dependencies.omo]]
     modId="forge"
     mandatory=true
-    versionRange="[39,)"
+    versionRange="[47,)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.omo]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.18.2]"
+    versionRange="[1.20,1.21)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
- Update Forge version range to [47,) for 1.20.1 support
- Adjust Minecraft version range to [1.20,1.21)
- Fixes #4